### PR TITLE
fix: use correct snapshot version after publishing

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -201,8 +201,7 @@ jobs:
           SNAPSHOT_VERSION=$VERSION
 
           # Persist the "version" in the gradle.properties
-          sed -i  's/version=.*/version=${{ github.event.inputs.version }}/g' gradle.properties
-
+          sed -i "s/version=.*/version=$SNAPSHOT_VERSION/g" gradle.properties
 
           # Commit and push to origin develop
           git add gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 groupId=org.eclipse.tractusx.edc
-version=
+version=0.3.2-SNAPSHOT
 javaVersion=11
 
 # configure the build:


### PR DESCRIPTION
## WHAT
This fix changes the release workflow so that it uses the correct SNAPSHOT version and sets it in the `gradle.properties`

## WHY
After a version has been published, the _new_ version should be a SNAPSHOT version, with the patch number increased by 1.